### PR TITLE
Download lists first

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ You have two paths here, a hard one and a slightly harder one.  Either way, you'
 
 ### The hard way
 
-Create a new repository in GitHub.com, then create an [`extra-actions.txt`](extra-actions.txt) file to suit your company's needs.  Create a workflow file in `.github/workflows/skills.yml`, example below.  
+Create a new repository in GitHub.com, then (optionally) create an [`extra-actions.txt`](extra-actions.txt) file to suit your company's needs.  Create a workflow file in `.github/workflows/skills.yml`, example below.
 
 ```yaml
-name: Export github.com/skills
+name: Bundle GitHub Actions to sync
 
 on:
   workflow_dispatch: # run on demand
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest # use the GitHub hosted runners
     steps:
       - name: Create the latest archive
-        uses: some-natalie/skilled-teleportation@main
+        uses: some-natalie/skilled-teleportation@v2
         with:
           list_file: extra-actions.txt
 ```

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,9 @@ runs:
             bin/actions-sync pull --cache-dir tmp/cache --repo-name "$line"
         done
 
+        # Get the list of dependencies for the Skills organization
+        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v1/skills-dependencies.txt -o skills-dependencies.txt -s
+
         # Sync dependencies for the Skills organization
         grep -v '^#' skills-dependencies.txt | grep . | while read -r line ; do
             bin/actions-sync pull --cache-dir tmp/cache --repo-name "$line"
@@ -81,6 +84,9 @@ runs:
       if: ${{ inputs.sync_templates }} = "true"
       shell: bash
       run: |
+        # Get the list of template repositories
+        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v1/template-actions.txt -o template-actions.txt -s
+
         # Sync all of github.com/actions templates
         grep -v '^#' template-actions.txt | grep . | while read -r line ; do
             bin/actions-sync pull --cache-dir tmp/cache --repo-name "$line"
@@ -104,7 +110,8 @@ runs:
     - name: "Copy in the push script"
       shell: bash
       run: |
-        cp scripts/teleport-push.sh tmp/
+        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v1/scripts/teleport-push.sh -o teleport-push.sh -s
+        cp teleport-push.sh tmp/
         chmod +x tmp/teleport-push.sh
 
     - name: "Upload the zip archive"

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
         done
 
         # Get the list of dependencies for the Skills organization
-        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v1/skills-dependencies.txt -o skills-dependencies.txt -s
+        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v2/skills-dependencies.txt -o skills-dependencies.txt -s
 
         # Sync dependencies for the Skills organization
         grep -v '^#' skills-dependencies.txt | grep . | while read -r line ; do
@@ -85,7 +85,7 @@ runs:
       shell: bash
       run: |
         # Get the list of template repositories
-        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v1/template-actions.txt -o template-actions.txt -s
+        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v2/template-actions.txt -o template-actions.txt -s
 
         # Sync all of github.com/actions templates
         grep -v '^#' template-actions.txt | grep . | while read -r line ; do
@@ -110,7 +110,7 @@ runs:
     - name: "Copy in the push script"
       shell: bash
       run: |
-        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v1/scripts/teleport-push.sh -o teleport-push.sh -s
+        curl https://raw.githubusercontent.com/some-natalie/skilled-teleportation/v2/scripts/teleport-push.sh -o teleport-push.sh -s
         cp teleport-push.sh tmp/
         chmod +x tmp/teleport-push.sh
 


### PR DESCRIPTION
This PR adds steps to download the dependency lists from this repo before trying to iteratively download them, preventing a "file doesn't exist" error when running this in a private repo.